### PR TITLE
Unit tests for the linear regression now allow any amount of white sp…

### DIFF
--- a/Testsuites/test_linreg_ref_class.R
+++ b/Testsuites/test_linreg_ref_class.R
@@ -20,7 +20,7 @@ test_that("print() method works", {
   linreg_mod <- linreg$new(Petal.Length~Sepal.Width+Sepal.Length, data=iris)
 
   expect_output(linreg_mod$print(),"linreg\\(formula = Petal\\.Length ~ Sepal\\.Width \\+ Sepal\\.Length, data = iris\\)")
-  expect_output(linreg_mod$print()," \\(Intercept\\)   Sepal\\.Width  Sepal\\.Length")
+  expect_output(linreg_mod$print(),"( )*\\(Intercept\\)( )*Sepal\\.Width( )*Sepal\\.Length")
 })
 
 test_that("pred() method works", {

--- a/Testsuites/test_linreg_s3.R
+++ b/Testsuites/test_linreg_s3.R
@@ -20,7 +20,7 @@ test_that("print() works", {
   linreg_mod <- linreg(Petal.Length~Sepal.Width+Sepal.Length, data=iris)
 
   expect_output(print(linreg_mod),"linreg\\(formula = Petal\\.Length ~ Sepal\\.Width \\+ Sepal\\.Length, data = iris\\)")
-  expect_output(print(linreg_mod)," \\(Intercept\\)   Sepal\\.Width  Sepal\\.Length")
+  expect_output(print(linreg_mod),"( )*\\(Intercept\\)( )*Sepal\\.Width( )*Sepal\\.Length")
 })
 
 test_that("pred() works", {


### PR DESCRIPTION
The unit test is failing because it expects a specific amount of white spaces (at one place 2, at another 3) in the `print()` function which makes it really hard to pass the unit test. This is especially weird, because for the `summary()` function any amount of white spaces is sufficient. This commit allows multiple white spaces for the RC and S3 unit tests.