### PR TITLE
Update regex in test_linreg_ref_class.R

### DIFF
--- a/Testsuites/test_linreg_ref_class.R
+++ b/Testsuites/test_linreg_ref_class.R
@@ -45,9 +45,9 @@ test_that("coef() method works", {
 test_that("summary() method works", {
   linreg_mod <- linreg$new(Petal.Length~Sepal.Width+Sepal.Length, data=iris)
   
-  expect_output(linreg_mod$summary(), "\\(Intercept\\)( )*-2.5[0-9]*( )*0.5[0-9]*( )*-4.4[0-9]*( )*.*( )*\\*\\*\\*")  
-  expect_output(linreg_mod$summary(), "Sepal.Width( )*-1.3[0-9]*( )*0.1[0-9]*( )*-10.9[0-9]*( )*.*( )*\\*\\*\\*")
-  expect_output(linreg_mod$summary(), "Sepal.Length( )*1.7[0-9]*( )*0.0[0-9]*( )*27.5[0-9]*( )*.*( )*\\*\\*\\*")
+  expect_output(linreg_mod$summary(), "\\(Intercept\\)( )*-2.5[0-9]*( )*0.5[0-9]*( )*-4.4[0-9]*( )*.*( )*")  
+  expect_output(linreg_mod$summary(), "Sepal.Width( )*-1.3[0-9]*( )*0.1[0-9]*( )*-10.9[0-9]*( )*.*( )*")
+  expect_output(linreg_mod$summary(), "Sepal.Length( )*1.7[0-9]*( )*0.0[0-9]*( )*27.5[0-9]*( )*.*( )*")
   expect_output(linreg_mod$summary(), "Residual standard error: 0.6[0-9]* on 147 degrees of freedom")
 })
 


### PR DESCRIPTION
The regex expects the summary output to have significance asterixes/stars at the end of the output, similar to when running `summary()` on an `lm()` object. The 2018 version of the lab assignment does not specify asterixes should be added at the end. 

Removing `\\*\\*\\*` takes care of the issue.